### PR TITLE
Easily add more directories

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,0 +1,18 @@
+Changes are below categorized as `Features, Fixes, or Misc`.
+
+Each change should fall into categories that would affect whether the release is major (breaking changes), minor (new behavior), or patch (bug fix). See [semver](http://semver.org/) and [pessimistic versioning](http://docs.rubygems.org/read/chapter/16#page74)
+
+As such, a _Feature_ would map to either major or minor. A _bug fix_ to a patch.  And _misc_ is either minor or patch, the difference being kind of fuzzy for the purposes of history.  Adding tests would be patch level.
+
+### Master
+
+* Features
+  * Easily configure additional directories to run on (Benjamin Fleischer, #5)
+* Fixes
+* Misc
+
+### 0.0.3   - 2013-07-10
+
+### 0.0.2   - 2013-07-05
+
+### 0.0.1   - 2013-07-03

--- a/lib/code_metrics/statistics.rb
+++ b/lib/code_metrics/statistics.rb
@@ -4,13 +4,7 @@ require 'code_metrics/stats_directories'
 module CodeMetrics
   class Statistics
 
-    TEST_TYPES = ['Controller tests',
-                  'Helper tests',
-                  'Model tests',
-                  'Mailer tests',
-                  'Integration tests',
-                  'Functional tests (old)',
-                  'Unit tests (old)']
+    TEST_TYPES = []
 
     def initialize(*pairs)
       @pairs      = pairs

--- a/lib/code_metrics/stats_directories.rb
+++ b/lib/code_metrics/stats_directories.rb
@@ -1,28 +1,132 @@
 # Try to get the root of the current project
+require 'pathname'
 module CodeMetrics
   class StatsDirectories
-    def initialize
-      @root = (defined?(Rails) &&  Rails.root) || Dir.pwd
+    StatDirectory = Struct.new(:description, :path) do
+      def to_a
+        [description, path]
+      end
+      def inspect
+        to_a.inspect
+      end
+      def directory?
+        File.directory?(path)
+      end
+      def name(file_pattern)
+        path.sub(/^\.\/(#{file_pattern}\/\w+)\/.*/, '\\1')
+      end
+      def self.from_list(list, path_prefix='')
+        list.map do |description, path|
+          new(description, [path_prefix,path].compact.join('/'))
+        end.select(&:directory?)
+      end
     end
-    def directories
-      [
-      %w(Controllers        app/controllers),
-      %w(Helpers            app/helpers),
-      %w(Models             app/models),
-      %w(Mailers            app/mailers),
-      %w(Javascripts        app/assets/javascripts),
-      %w(Libraries          lib/),
-      %w(APIs               app/apis),
-      %w(Controller\ tests  test/controllers),
-      %w(Helper\ tests      test/helpers),
-      %w(Model\ tests       test/models),
-      %w(Mailer\ tests      test/mailers),
-      %w(Integration\ tests test/integration),
-      %w(Functional\ tests\ (old)  test/functional),
-      %w(Unit\ tests \ (old)       test/unit)
-    ].collect { |name, dir| [ name, "#{@root}/#{dir}" ] }
-     .select { |name, dir| File.directory?(dir) }
 
+    attr_reader :app_directories, :test_directories
+
+    def initialize
+      @root = path_prefix
+      @app_directories = default_app_directories
+      @test_directories = default_test_directories
+    end
+
+    def directories
+      app_directories.map(&:to_a) | test_directories.map(&:to_a)
+    end
+
+    # What Rails expects
+    def default_app_directories
+      StatDirectory.from_list([
+        %w(Controllers        app/controllers),
+        %w(Helpers            app/helpers),
+        %w(Models             app/models),
+        %w(Mailers            app/mailers),
+        %w(Javascripts        app/assets/javascripts),
+        %w(Libraries          lib),
+        %w(APIs               app/apis)
+      ], @root)
+    end
+
+    def default_test_directories
+      StatDirectory.from_list([
+        %w(Controller\ tests  test/controllers),
+        %w(Helper\ tests      test/helpers),
+        %w(Model\ tests       test/models),
+        %w(Mailer\ tests      test/mailers),
+        %w(Integration\ tests test/integration),
+        %w(Functional\ tests\ (old)  test/functional),
+        %w(Unit\ tests \ (old)       test/unit)
+      ], @root)
+    end
+
+    # @example add_directories('./spec/**/*_spec.rb', 'spec')
+    #   will build dirs with the format of description, path:
+    #   [ 'Acceptance specs', 'spec/acceptance' ]
+    def add_directories(dir_pattern, file_pattern)
+      build_directories(dir_pattern, file_pattern).each do |description, path|
+        add_directory(description, path)
+      end
+      self
+    end
+
+    def add_test_directories(dir_pattern, file_pattern)
+      build_directories(dir_pattern, file_pattern).each do |description, path|
+        add_test_directory(description, path)
+      end
+      self
+    end
+
+    def add_directory(description,folder_path)
+      folder_path = folder_path.to_s
+      unless app_directories.any?{|stat_dir| stat_dir.path == folder_path}
+        app_directories << StatDirectory.new(description, folder_path)
+      end
+      self
+    end
+
+    def add_test_directory(description,folder_path)
+      folder_path = folder_path.to_s
+      unless test_directories.any?{|stat_dir| stat_dir.path == folder_path}
+        test_directories << StatDirectory.new(description, folder_path)
+        CodeMetrics::Statistics::TEST_TYPES << description
+      end
+      self
+    end
+
+    # @example build_directories('./spec/**/*_spec.rb', 'spec')
+    def build_directories(glob_pattern, file_pattern)
+      dirs = collect_directories(glob_pattern, file_pattern)
+
+      Hash[dirs.map { |path|
+            [description(path.basename,file_pattern), path]
+            }
+          ]
+    end
+    # collects non empty directories and names the metric by the folder name
+    # parent? or dirname? or basename?
+    def collect_directories(glob_pattern, file_pattern='')
+      Pathname.glob(glob_pattern).select{|f| f.basename.to_s.include?(file_pattern) }.map(&:dirname).uniq.map(&:realpath)
+    end
+
+    def description(path_basename,file_pattern)
+      if path_basename.to_s == file_pattern
+        "Uncategorized #{pluralize(file_pattern)}"
+      else
+       "#{titlecase(path_basename)} #{pluralize(file_pattern)}"
+      end.strip
+    end
+
+    def titlecase(string)
+      string = string.to_s
+      "#{string[0..0].upcase}#{string[1..-1]}"
+    end
+
+    def pluralize(string)
+      "#{string}s" unless string.to_s.empty?
+    end
+
+    def path_prefix
+       (defined?(Rails) &&  Rails.root) || Pathname.pwd
     end
   end
 end


### PR DESCRIPTION
Add easy helper methods for adding more app or test directories

``` ruby
c = CodeMetrics::StatsDirectories.new
c.add_test_directories('spec/**/*_spec.rb', 'spec') # where the 2nd argument is a required string in the filename
c.add_directories('engines/**/*.rb') # no restrictions on the file name, 2nd argument omitted
c.directories # outputs an array of [description, folder_path] to run statistics against
```

Logic inspired by https://github.com/rspec/rspec-rails/blob/d546278af1/lib/rspec/rails/tasks/rspec.rake#L43
