### PR TITLE
Add default test directory descriptions to Statistics::TEST_TYPES.

### DIFF
--- a/lib/code_metrics/stats_directories.rb
+++ b/lib/code_metrics/stats_directories.rb
@@ -28,6 +28,7 @@ module CodeMetrics
       @root = path_prefix
       @app_directories = default_app_directories
       @test_directories = default_test_directories
+      @test_directories.each { |pair| CodeMetrics::Statistics::TEST_TYPES << pair.first }
     end
 
     def directories

--- a/lib/code_metrics/stats_directories.rb
+++ b/lib/code_metrics/stats_directories.rb
@@ -28,7 +28,9 @@ module CodeMetrics
       @root = path_prefix
       @app_directories = default_app_directories
       @test_directories = default_test_directories
-      @test_directories.each { |pair| CodeMetrics::Statistics::TEST_TYPES << pair.first }
+      @test_directories.each do |pair|
+        CodeMetrics::Statistics::TEST_TYPES << pair.first
+      end
     end
 
     def directories

--- a/test/dummy/test/controllers/application_controller_test.rb
+++ b/test/dummy/test/controllers/application_controller_test.rb
@@ -1,0 +1,9 @@
+class ApplicationControllerTest < ActionController::TestCase
+  test "truth" do
+    assert true
+  end
+
+  test "negativity" do
+    assert_not false
+  end
+end

--- a/test/rake_test.rb
+++ b/test/rake_test.rb
@@ -6,7 +6,7 @@ module CodeMetrics
   class RakeTest < ActiveSupport::TestCase
 
     def test_code_metrics_sanity
-      assert_match "Code LOC: 5     Test LOC: 0     Code to Test Ratio: 1:0.0",
+      assert_match "Code LOC: 5     Test LOC: 8     Code to Test Ratio: 1:1.6",
         Dir.chdir(app_path){ `rake code_metrics:stats` }
     end
 


### PR DESCRIPTION
"Test LOC" is always 0 unless you have manually configured test your
test directories via CodeMetrics::StatsDirectories#add_test_directory,
CodeMetrics::StatsDirectories#add_test_directories, etc.

Modify CodeMetrics::Statistics#initialize so that the default test
directories are also added to the CodeMetrics::Statistics::TEST_TYPES
array.  This allows CodeMetrics::Statistics#calculate_tests to work
in the default configuration case (eg., when using "metric_fu" without
and custom "code_metrics" configuration changes).

Also, add a dummy controller test and adjust the expected results
in the test_code_metrics_sanity to look for the correct, updated
values for "Test LOC" and "Code to Test Ratio".
